### PR TITLE
Conditionally overwrite log.config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,11 +23,18 @@ export default class extends EventEmitter {
     log.main('config file path: %s', this.options.configFile);
     log.main('log file path: %s', this.options.logFile);
 
-    // Copy local config file to the correct location.
-    // We're just gonna do this every time.
+    // Copy local config file to the correct location. Unless already exists.
+    // Don't want to break other trackers
     var localConfigFile = path.join(__dirname, './log.config');
-    fs.createReadStream(localConfigFile).pipe(fs.createWriteStream(this.options.configFile));
-    log.main('Copied log.config file to force Hearthstone to write to its log file.');
+    fs.access(localConfigFile, (err) => {
+      if (err) {
+        // log config file does not exist
+        fs.createReadStream(localConfigFile).pipe(fs.createWriteStream(this.options.configFile));
+        log.main('Copied log.config file to force Hearthstone to write to its log file.');
+      } else {
+        log.main('Using pre-exisiting log.config file.');
+      }
+    });
   }
 
   start () {


### PR DESCRIPTION
By overwriting the log.config file every time, farseer runs the risk of disabling other programs watching the Hearthstone logs, as it did for me this morning.

Now, farseer will only write log.config if it doesn't already exist. This operates on the assumption that if a log.config is already there, it's probably been put there intentionally, and it likely already does what we need it to do.

In the future, I imagine farseer could parse any existing log.config and add any additional configuration it might need to function.