### PR TITLE
Add editorconfig dot file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true


### PR DESCRIPTION
This helps keep code style conventions in place when using multiple IDEs and/or text editors. So one project can be configured with 4 spaces, another with 2 spaces, and the editor won't need to be reconfigured.

A handful of editors support this natively. For others there is a plugin.

http://editorconfig.org/

Note: This PR isn't a must, but just something handy I like to use.