### PR TITLE
A fix for fs.WatchFile delays

### DIFF
--- a/src/default-options.js
+++ b/src/default-options.js
@@ -3,7 +3,8 @@ import path from 'path';
 
 export default function (log) {
   let defaultOptions = {
-    endOfLineChar: os.EOL
+    endOfLineChar: os.EOL,
+    fsPollInterval: 250
   };
   // Determine the default location of the config and log files.
   if (/^win/.test(os.platform())) {

--- a/src/index.js
+++ b/src/index.js
@@ -45,8 +45,8 @@ export default class extends EventEmitter {
     log.main('Log watcher started.');
     // Begin watching the Hearthstone log file.
     var fileSize = fs.statSync(self.options.logFile).size;
-    fs.watchFile(self.options.logFile, function (current, previous) {
-      if (current.mtime <= previous.mtime) { return; }
+    fs.watchFile(self.options.logFile, {interval: self.options.fsPollInterval}, function (current, previous) {
+      if (current.size <= previous.size) { return; }
 
       // We're only going to read the portion of the file that we have not read so far.
       var newFileSize = fs.statSync(self.options.logFile).size;


### PR DESCRIPTION
I noticed some lag between an event occurring in Hearthstone and being presented in Farseer. On closer inspection, it seems that fs.WatchFile has a default polling rate of 5007 milliseconds. I added an option with a lower default polling time of 250 (if that's too fast, it can be changed to something more reasonable.) 

I saw that some code had been added to prevent duplicate events from firing off fs.WatchFile, which seems to be a known bug, but realized since the Hearthstone output log only grows, we could instead monitor fs.Stats' size property to see if we're looking at the same event.